### PR TITLE
Update lunar events for 2022

### DIFF
--- a/events/diwali/meta.md
+++ b/events/diwali/meta.md
@@ -1,6 +1,6 @@
 ---
-start_date: November 1
-end_date: November 7
+start_date: October 19
+end_date: October 25
 ---
 **Diwali**
 

--- a/events/halloween/meta.md
+++ b/events/halloween/meta.md
@@ -1,6 +1,6 @@
 ---
-start_date: October 14
-end_date: October 31
+start_date: October 26
+end_date: November 1
 ---
 **Halloween**
 

--- a/events/holi/meta.md
+++ b/events/holi/meta.md
@@ -1,6 +1,6 @@
 ---
-start_date: March 24
-end_date: March 30
+start_date: March 18
+end_date: March 24
 ---
 **Holi**
 

--- a/events/st_patricks_day/meta.md
+++ b/events/st_patricks_day/meta.md
@@ -1,6 +1,6 @@
 ---
 start_date: March 15
-end_date: March 18
+end_date: March 17
 ---
 **Saint Patrick's Day**
 


### PR DESCRIPTION
This PR accounts for some adjustments for lunar events of 2022.

- Holi is bumped up approximately a week to March 18.
- St Patrick's Day event is shortened by 1 day as a result.
- Diwali is bumped up approximately 2 weeks to October 19.
- Halloween event is shortened to 1 week as a result.

These days can be adjusted again next year because according to Google, Holi 2023 will be in early March and Diwali 2023 will be in November again.