### PR TITLE
Update Holi duration and timing description

### DIFF
--- a/events/holi/meta.md
+++ b/events/holi/meta.md
@@ -4,4 +4,4 @@ end_date: March 13
 ---
 **Holi**
 
-[Holi](https://en.wikipedia.org/wiki/Holi) is an annual festival of colours and one of the major festivals celebrated by Hindus, Jains and Sikhs. It usually lasts five days and falls in mid to late March.
+[Holi](https://en.wikipedia.org/wiki/Holi) is an annual festival of colours and one of the major festivals celebrated by Hindus, Jains and Sikhs. It lasts two days, starting on the evening of the Purnima (Full Moon Day) falling in the Hindu calendar month of Phalguna, which falls around the middle of March in the Gregorian calendar.


### PR DESCRIPTION
Updating duration from "usually lasts 5 days" to "2 days", as well as a longer explanation on the timing of the event. 