### PR TITLE
Update dates for easter and diwali

### DIFF
--- a/events/diwali/meta.md
+++ b/events/diwali/meta.md
@@ -1,6 +1,6 @@
 ---
-start_date: October 20
-end_date: October 25
+start_date: November 6
+end_date: November 11
 ---
 **Diwali**
 

--- a/events/easter/meta.md
+++ b/events/easter/meta.md
@@ -1,6 +1,6 @@
 ---
-start_date: April 5
-end_date: April 5
+start_date: March 28
+end_date: March 28
 ---
 **Easter**
 

--- a/events/easter/meta.md
+++ b/events/easter/meta.md
@@ -1,6 +1,6 @@
 ---
-start_date: April 20
-end_date: April 20
+start_date: April 5
+end_date: April 5
 ---
 **Easter**
 


### PR DESCRIPTION
Previously used the date for easter 2025, which caused it to be displayed on the wrong date in 2026. Update to use the dates for 2027, so it's ready for next year.

Also updates Diwali to the correct dates for 2026, as requested by @swfarnsworth.